### PR TITLE
Extend assoc-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,11 @@
 
 ### Add
 
+- Variadic arity assoc-in. The analysis collapses all paths to a tree
+  with leaves being the values to be assoc-ed and plans out a minimal
+  execution. Also see [#23](https://github.com/bsless/clj-fast/issues/23)
 - Tests from Clojure's test suit to catch some edge cases
-- Faster update-in which takes advantage of variadic arities, bug introduces ugly code duplication
+- Faster update-in which takes advantage of variadic arities, but introduces ugly code duplication
 
 ### Fix
 

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ Examples:
 
 (inline/assoc-in m [:c :d] foo)
 
+(inline/assoc-in m [:c :d] foo [:c :b] bar)
+
 (inline/update-in m [:c :d] inc)
 
 (inline/select-keys m [:a :b :c])
@@ -139,6 +141,8 @@ Examples:
 ##### Notes
 
 - Merge analysis unrolls inline maps as well.
+- Warning: additional arities of assoc-in will cause code reordering.
+  Beware of side effects.
 
 ##### Additions
 

--- a/src/clj_fast/inline.clj
+++ b/src/clj_fast/inline.clj
@@ -203,7 +203,11 @@
 (defmacro assoc-in
   "Like assoc-in but inlines the calls when a static sequence of keys is
   provided.
-  Can take an unlimited number of [ks v] pairs"
+  Can take an unlimited number of [ks v] pairs.
+  Caution:
+  For more than one path-value pair this macro will reorder your code
+  and eliminate forms. Rely on side-effects and order at your own
+  peril."
   [m & ksvs]
   {:pre [(every? u/simple-seq? (take-nth 2 ksvs))]}
   (lens/put-many

--- a/src/clj_fast/inline.clj
+++ b/src/clj_fast/inline.clj
@@ -189,6 +189,7 @@
     `(let ~bindings
        ~form)))
 
+#_
 (defmacro assoc-in
   "Like assoc-in but inlines the calls when a static sequence of keys is
   provided."
@@ -199,10 +200,12 @@
    (fn [m k] `(c/get ~m ~k))
    m (u/simple-seq ks) v))
 
-(defmacro assoc-in+
+(defmacro assoc-in
   "Like assoc-in but inlines the calls when a static sequence of keys is
-  provided."
+  provided.
+  Can take an unlimited number of [ks v] pairs"
   [m & ksvs]
+  {:pre [(every? u/simple-seq? (take-nth 2 ksvs))]}
   (lens/put-many
    (fn [m k v] `(c/assoc ~m ~k ~v))
    (fn [m k] `(c/get ~m ~k))

--- a/src/clj_fast/inline.clj
+++ b/src/clj_fast/inline.clj
@@ -199,45 +199,14 @@
    (fn [m k] `(c/get ~m ~k))
    m (u/simple-seq ks) v))
 
-(defn- collapse
-  [kvs]
-  (reduce
-   (fn [m [path v]]
-     (c/assoc-in m (map (fn [k] {::node k}) path) {::leaf v}))
-   {}
-   kvs))
-
-(defn- explode
-  [m form]
-  (let [parent (gensym "parent__")
-        bindings
-        (reduce
-         (fn [bs [k v]]
-           (if (::leaf v)
-             (conj bs parent `(c/assoc ~parent ~(::node k) ~(::leaf v)))
-             (let [child (gensym "child__")]
-               (conj bs
-                     child `(c/get ~parent ~(::node k))
-                     parent `(c/assoc ~parent ~(::node k) ~(explode child v))))))
-         [parent m]
-         form)]
-    `(let [~@bindings]
-       ~parent)))
-
-(comment
-  (def kvs
-    [[[:x :y] 1]
-     [[:x :z :a] 2]
-     [[:x :z :b] 3]
-     [[:x :z :c] 4]])
-
-  (explode 'm (collapse kvs)))
-
 (defmacro assoc-in+
   "Like assoc-in but inlines the calls when a static sequence of keys is
   provided."
-  [m ks v & ksvs]
-  (explode m (collapse (into [[ks v]] (partition 2 ksvs)))))
+  [m & ksvs]
+  (lens/put-many
+   (fn [m k v] `(c/assoc ~m ~k ~v))
+   (fn [m k] `(c/get ~m ~k))
+   m ksvs))
 
 (defmacro update-in
   "Like update-in but inlines the calls when a static sequence of keys is

--- a/test/clj_fast/inline_test.clj
+++ b/test/clj_fast/inline_test.clj
@@ -70,6 +70,14 @@
     (t/is (= {:a 2} (sut/assoc-in m [:a] 2)))
     (t/is (= {:a {:b 1 4 2}} (sut/assoc-in m [:a (inc 3)] 2)))))
 
+(t/deftest assoc-in+
+  (let [m {:a {:b 1}}]
+    (t/is (= {:a {:b 2}} (sut/assoc-in+ m [:a :b] 2)))
+    (t/is (= {:a {:b 2 :c 3}} (sut/assoc-in+ m [:a :b] 2 [:a :c] 3)))
+    (t/is (= {:a 2} (sut/assoc-in+ m [:a] 2)))
+    (t/is (= {:a 2 :b 3} (sut/assoc-in+ m [:a] 2 [:b] 3)))
+    (t/is (= {:a {:b 1 4 2}} (sut/assoc-in+ m [:a (inc 3)] 2)))))
+
 (t/deftest update-in
   (let [m {:a {:b 1}}]
     (t/is (= {:a {:b 2}} (sut/update-in m [:a :b] + 1)))

--- a/test/clj_fast/inline_test.clj
+++ b/test/clj_fast/inline_test.clj
@@ -64,19 +64,20 @@
       (t/is (= {:a 1 :b 2} (sut/fast-select-keys m [:a :b])))
       (t/is (= {:a 1 :c nil} (sut/fast-select-keys m [:a :c]))))))
 
+#_
 (t/deftest assoc-in
   (let [m {:a {:b 1}}]
     (t/is (= {:a {:b 2}} (sut/assoc-in m [:a :b] 2)))
     (t/is (= {:a 2} (sut/assoc-in m [:a] 2)))
     (t/is (= {:a {:b 1 4 2}} (sut/assoc-in m [:a (inc 3)] 2)))))
 
-(t/deftest assoc-in+
+(t/deftest assoc-in
   (let [m {:a {:b 1}}]
-    (t/is (= {:a {:b 2}} (sut/assoc-in+ m [:a :b] 2)))
-    (t/is (= {:a {:b 2 :c 3}} (sut/assoc-in+ m [:a :b] 2 [:a :c] 3)))
-    (t/is (= {:a 2} (sut/assoc-in+ m [:a] 2)))
-    (t/is (= {:a 2 :b 3} (sut/assoc-in+ m [:a] 2 [:b] 3)))
-    (t/is (= {:a {:b 1 4 2}} (sut/assoc-in+ m [:a (inc 3)] 2)))))
+    (t/is (= {:a {:b 2}} (sut/assoc-in m [:a :b] 2)))
+    (t/is (= {:a {:b 2 :c 3}} (sut/assoc-in m [:a :b] 2 [:a :c] 3)))
+    (t/is (= {:a 2} (sut/assoc-in m [:a] 2)))
+    (t/is (= {:a 2 :b 3} (sut/assoc-in m [:a] 2 [:b] 3)))
+    (t/is (= {:a {:b 1 4 2}} (sut/assoc-in m [:a (inc 3)] 2)))))
 
 (t/deftest update-in
   (let [m {:a {:b 1}}]


### PR DESCRIPTION
Extend inline/assoc-in's arity to be variadic

Input paths are collected and execution is pre-planned such that a
minimal number of get-s and assoc-s are performed.

Based on suggestion by @yuhan0 at #23