### PR TITLE
Add fast subseq and rsubseq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 - Not found arity to inline/get-in
 - Tests from Clojure's test suit to catch some edge cases
 - Faster update-in which takes advantage of variadic arities, but introduces ugly code duplication
+- Faster versions of subseq/rsubseq which don't use sets for checking
+  test functions identity.
 
 ### Fix
 

--- a/test/clj_fast/clojure/core_test.clj
+++ b/test/clj_fast/clojure/core_test.clj
@@ -121,3 +121,10 @@
         {:a 3} (sut/update-in m ks + 1 1)
         {:a 4} (sut/update-in m ks + 1 1 1)
         {:a 5} (sut/update-in m ks + 1 1 1 1)))))
+
+(t/deftest test-subseq
+  (let [s1 (range 100)
+        s2 (into (sorted-set) s1)]
+    (doseq [i (range 100)]
+      (t/is (= s1 (concat (sut/subseq s2 < i) (sut/subseq s2 >= i))))
+      (t/is (= (reverse s1) (concat (sut/rsubseq s2 >= i) (sut/rsubseq s2 < i)))))))


### PR DESCRIPTION
core/subseq uses a set to check test function identity. By using
identity check directly its performance can be significantly improved

Closes #18