### PR TITLE
[WIP] Add update-many, update-many-> macros

### DIFF
--- a/src/clj_fast/inline.clj
+++ b/src/clj_fast/inline.clj
@@ -222,6 +222,27 @@
    (fn [m k] `(c/get ~m ~k))
    m ksvs))
 
+(defmacro update-many
+  [m & ksfs]
+  (lens/update-many
+   (fn [m k fv] `(c/assoc ~m ~k ~fv))
+   (fn [m k] `(c/get ~m ~k))
+   (fn [f v] `(~f ~v))
+   m ksfs))
+
+(defmacro update-many->
+  "Takes an unlimited number of [ks f] pairs.
+  f are forms to be applied to existing values in a -> threading macro.
+  ~Unquoted values are overriden like in assoc-in."
+  [m & ksfs]
+  (lens/update-many
+   (fn [m k fv] `(c/assoc ~m ~k ~fv))
+   (fn [m k] `(c/get ~m ~k))
+   (fn [f v] (if (and (seq? f) (= `c/unquote (first f)))
+               (second f)
+               `(-> ~v ~f)))
+   m ksfs))
+
 (defmacro update-in
   "Like update-in but inlines the calls when a static sequence of keys is
   provided."


### PR DESCRIPTION
I tried generalising the logic from the recent assoc-in changes, to allow for arbitrary updates to multiple nested keys.

Not sure if I fully understand functional lenses, so there might be a more elegant way of doing this than adding another `updater` parameter. All docstrings are WIP.

The proposed API here adds two macros:
`update-many` is like clojure.core/update-in but restricted to single-arity functions,
whereas `update-many->` treats the "functions" as threading macro forms so they can be inlined at compile time.
```clj
;; clojure.core

(-> m
  (update-in [:a :b] f)
  (update-in [:c :d] g x y z))

;; becomes:
(update-many m
  [:a :b] f
  [:c :d] #(g % x y z))
;; or
(update-many-> m
  [:a :b] (f)
  [:c :d] (g ,, x y z))
```

I also added a unquoting feature which treats the value as something to be assoc'ed: This could of course be achieved with less magic using `(constantly newval)` or defining  something like `(defmacro const-> [_ v] v)` to be used in the threading macro.

```clj
(update-many-> {:xs    [1 2 3 4 5]
                :cube  4
                :assoc "old"}
  ;; threading macro allows for updating in different positions
  [:xs]   (->> (map dec) (take 3))
  [:cube] (as-> it (* it it it))

  ;; using unquote for assoc-like functionality
  [:assoc] ~"new")
;; => {:xs (0 1 2), :cube 64, :assoc "new"}
```
